### PR TITLE
fix: update contact attribute key to match example contact flow

### DIFF
--- a/Code/Core/sub_connect_task.py
+++ b/Code/Core/sub_connect_task.py
@@ -35,8 +35,8 @@ def vmx_to_connect_task(writer_payload):
 
     # Check for a task flow to use, if not, use default
     if 'vmx_task_flow' in writer_payload['json_attributes']:
-        if writer_payload['json_attributes']['vmx_task_flow']:
-            contact_flow = writer_payload['json_attributes']['vmx_task_flow']
+        if writer_payload['json_attributes']['vmx3_task_flow']:
+            contact_flow = writer_payload['json_attributes']['vmx3_task_flow']
         else:
             writer_payload.update({'task_flow':os.environ['default_task_flow']})
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
vmx_task_flow is inconsistent with other referenced attributes, and does not match the attribute provided in the example contact flow; causing changes to the flow ID to be ignored.

updates vmx_task_flow attribute key in packager sub_connect_task to vmx3_task_flow

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
