### PR TITLE
Add date time attribute to task

### DIFF
--- a/Code/Core/vmx3_packager.py
+++ b/Code/Core/vmx3_packager.py
@@ -22,6 +22,7 @@ import os
 import logging
 import boto3
 import phonenumbers
+from datetime import datetime, timezone
 
 # Import the VMX Model Type
 import sub_connect_task
@@ -156,6 +157,9 @@ def lambda_handler(event, context):
             logger.error('Record Result: Failed to extract queue name')
             entity_name = 'UNKNOWN'
 
+    # Get the current date and time in UTC using timezone-aware objects
+    current_datetime = datetime.now(timezone.utc).isoformat()
+
     # Get the existing contact attributes from the call and append the standard vars for voicemail to the attributes
     try:
         contact_attributes = connect_client.get_contact_attributes(
@@ -163,7 +167,7 @@ def lambda_handler(event, context):
             InitialContactId = contact_id
         )
         json_attributes = contact_attributes['Attributes']
-        json_attributes.update({'entity_name':entity_name,'entity_id':entity_id,'entity_description':entity_description,'transcript_contents':transcript_contents,'callback_number':json_attributes['vmx3_from'],'presigned_url':raw_url})
+        json_attributes.update({'entity_name':entity_name,'entity_id':entity_id,'entity_description':entity_description,'transcript_contents':transcript_contents,'callback_number':json_attributes['vmx3_from'],'presigned_url':raw_url,'vmx3_dateTime': current_datetime})
         writer_payload.update({'json_attributes':json_attributes})
         contact_attributes = json.dumps(contact_attributes['Attributes'])
 


### PR DESCRIPTION
*Description of changes:* 

By adding a date time attribute to the task, we are able to know when the voicemail was left, as the customer may have spoken to a live agent since leaving the message.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
