### PR TITLE
Configure KMS Key Policies for Kinesis Video Streams Encryption

### DIFF
--- a/CloudFormation/vmx3-policy-builder.yaml
+++ b/CloudFormation/vmx3-policy-builder.yaml
@@ -27,6 +27,8 @@ Parameters:
     Type: String
   VMXKVSStreamPrefix:
     Type: String
+  VMXKVSStreamKMSKeyARN:
+    Type: String
   ConnectCTRStreamARN:
     Type: String
   AWSRegion:
@@ -121,6 +123,11 @@ Resources:
               - 'kinesis:ListShards'
               - 'kinesis:ListStreams'
             Resource: !Ref ConnectCTRStreamARN       
+          - Effect: Allow
+            Action:
+              - 'kms:Decrypt'
+              - 'kms:GenerateDataKey'
+            Resource: !Ref VMXKVSStreamKMSKeyARN
       ManagedPolicyName:
         !Join
           - ''

--- a/CloudFormation/vmx3.yaml
+++ b/CloudFormation/vmx3.yaml
@@ -12,6 +12,7 @@ Metadata:
           - ConnectInstanceAlias
           - ConnectInstanceARN
           - VMXKVSStreamPrefix
+          - VMXKVSStreamKMSKeyARN
           - ConnectCTRStreamARN
           - LambdaLoggingLevel
       - Label:
@@ -86,6 +87,8 @@ Metadata:
           minutes)
       VMXKVSStreamPrefix:
         default: What is the prefix for the Kinesis Video Streams (KVS) associated with this instance?
+      VMXKVSStreamKMSKeyARN:
+        default: What is the ARN (Amazon Resource Name) of the KMS key used for encrypting data in the Amazon Kinesis Video Streams (KVS) associated with this instance?
       LambdaLoggingLevel:
         default: For the included AWS Lambda functions, what should the default logging
           level be set to?
@@ -149,8 +152,14 @@ Parameters:
     Description: Not required and only used for development purposes.
   VMXKVSStreamPrefix:
     Type: String
-    Default: 'Looks like - PREFIX-connect-ALIAS-contact-'
-    Description: The full prefix for the KVS streams. You can find this in the Connect Console at Data Storage > Live media Streaming > Kinesis video stream prefix.
+    Default: Looks like - PREFIX-connect-ALIAS-contact-
+    Description: The full prefix for the KVS streams. You can find this in the
+      Connect Console at Data Storage > Live media Streaming > Kinesis video
+      stream prefix.
+  VMXKVSStreamKMSKeyARN:
+    Type: String
+    Default: Looks like - arn:aws:kms:REGION:ACCOUNT:key/REPLACEME
+    Description: The full ARN for the KMS key used for KVS streams. You can find this in the Connect Console at Data Storage > Live media Streaming > Encryption.
   EmailRecordingLinksExpireInXDays:
     Type: String
     Default: 1
@@ -504,6 +513,7 @@ Resources:
         VMXS3RecordingsBucketArn: !GetAtt VMXCoreStack.Outputs.VMXS3RecordingsBuckettArn
         VMXS3TranscriptsBucketArn: !GetAtt VMXCoreStack.Outputs.VMXS3TranscriptsBucketArn
         VMXKVSStreamPrefix: !Ref VMXKVSStreamPrefix
+        VMXKVSStreamKMSKeyARN: !Ref VMXKVSStreamKMSKeyARN
         ConnectCTRStreamARN: !Ref ConnectCTRStreamARN
         AWSRegion: !Ref AWSRegion
         VMXPresignerArn: !If

--- a/CloudFormation/vmx3.yaml
+++ b/CloudFormation/vmx3.yaml
@@ -152,7 +152,7 @@ Parameters:
     Description: Not required and only used for development purposes.
   VMXKVSStreamPrefix:
     Type: String
-    Default: Looks like - PREFIX-connect-ALIAS-contact-
+    Default: 'Looks like - PREFIX-connect-ALIAS-contact-'
     Description: The full prefix for the KVS streams. You can find this in the Connect Console at Data Storage > Live media Streaming > Kinesis video stream prefix.
   VMXKVSStreamKMSKeyARN:
     Type: String

--- a/CloudFormation/vmx3.yaml
+++ b/CloudFormation/vmx3.yaml
@@ -153,9 +153,7 @@ Parameters:
   VMXKVSStreamPrefix:
     Type: String
     Default: Looks like - PREFIX-connect-ALIAS-contact-
-    Description: The full prefix for the KVS streams. You can find this in the
-      Connect Console at Data Storage > Live media Streaming > Kinesis video
-      stream prefix.
+    Description: The full prefix for the KVS streams. You can find this in the Connect Console at Data Storage > Live media Streaming > Kinesis video stream prefix.
   VMXKVSStreamKMSKeyARN:
     Type: String
     Default: Looks like - arn:aws:kms:REGION:ACCOUNT:key/REPLACEME


### PR DESCRIPTION
*[Issue #, if available](https://github.com/amazon-connect/voicemail-express-amazon-connect/issues/36):* 

*Description of changes:* This pull request addresses an issue encountered when using a customer-managed KMS key for encryption in Kinesis Video Streams (KVS). While the default KMS key works without any problems, using a customer-managed key leads to certain complications.

Changes made in this pull request:

- Implemented KMS key policies specifically tailored for the encryption key used in Kinesis Video Streams.
- Ensured that the necessary permissions are in place for the customer-managed KMS key.
- Tested the implementation to verify that encryption and decryption operations function correctly with the configured key policies.

By applying these changes, we can now successfully utilize customer-managed KMS keys for encryption in Kinesis Video Streams, providing enhanced security and control over the encryption process.

Please review the modifications and provide any feedback or suggestions for improvement.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
