### PR TITLE
Implement Custom KMS Key Policies for Kinesis Data Streams Encryption

### DIFF
--- a/CloudFormation/vmx3-policy-builder.yaml
+++ b/CloudFormation/vmx3-policy-builder.yaml
@@ -29,6 +29,8 @@ Parameters:
     Type: String
   ConnectCTRStreamARN:
     Type: String
+  ConnectCTRStreamKMSKeyARN:
+    Type: String
   AWSRegion:
     Type: String
   VMXPresignerArn:
@@ -54,6 +56,7 @@ Conditions:
   ConnectGuidedTasksEnabled: !Equals
     - !Ref EnableVMToConnectGuidedTask
     - 'yes'
+  HasCTRStreamKMSKeyARN: !Not [!Equals [!Ref ConnectCTRStreamKMSKeyARN, '']]
 
 Resources:
   VMXGuidedFlowPresignerPolicy:
@@ -120,7 +123,15 @@ Resources:
               - 'kinesis:GetShardIterator'
               - 'kinesis:ListShards'
               - 'kinesis:ListStreams'
-            Resource: !Ref ConnectCTRStreamARN       
+            Resource: !Ref ConnectCTRStreamARN     
+          - !If 
+            - HasCTRStreamKMSKeyARN
+            - Effect: Allow
+              Action: 
+              - 'kms:Decrypt'
+              - 'kms:GenerateDataKey'
+              Resource: !Ref ConnectCTRStreamKMSKeyARN 
+            - !Ref AWS::NoValue
       ManagedPolicyName:
         !Join
           - ''

--- a/CloudFormation/vmx3.yaml
+++ b/CloudFormation/vmx3.yaml
@@ -13,6 +13,7 @@ Metadata:
           - ConnectInstanceARN
           - VMXKVSStreamPrefix
           - ConnectCTRStreamARN
+          - ConnectCTRStreamKMSKeyARN
           - LambdaLoggingLevel
       - Label:
           default: 2. Voicemail Express AWS Delivery Modes
@@ -58,8 +59,9 @@ Metadata:
       AWSRegion:
         default: Which AWS region is your Amazon Connect Instance deployed to?
       ConnectCTRStreamARN:
-        default: What is the ARN for the Kinesis Data Stream that is configured for
-          Contact Record streaming.
+        default: What is the ARN for the Kinesis Data Stream that is configured for Contact Record streaming.
+      ConnectCTRStreamKMSKeyARN:
+        default: Enter the ARN of the customer-managed KMS Key for Kinesis Data Stream encryption. Leave empty if using AWS-managed KMS Key or if encryption is Disabled.
       ConnectInstanceAlias:
         default: What is your Amazon Connect instance alias?
       ConnectInstanceARN:
@@ -133,6 +135,11 @@ Parameters:
     Description: Provide the ARN for the Kinesis Data Stream that receives your
       contact records. This solution is only designed for Amazon Kinesis Data
       Streams, not Kinesis Data Firehose.
+  ConnectCTRStreamKMSKeyARN:
+    Type: String
+    Default: Looks like - arn:aws:kms:REGION:ACCOUNT:key/REPLACEME
+    Description: Provide the ARN for the KMS Key configured on Kinesis Data Stream that receives your
+      contact records. Not required if using AWS-managed KMS Key or if encryption is disabled.
   ConnectInstanceAlias:
     Type: String
     Default: REPLACEME
@@ -505,6 +512,7 @@ Resources:
         VMXS3TranscriptsBucketArn: !GetAtt VMXCoreStack.Outputs.VMXS3TranscriptsBucketArn
         VMXKVSStreamPrefix: !Ref VMXKVSStreamPrefix
         ConnectCTRStreamARN: !Ref ConnectCTRStreamARN
+        ConnectCTRStreamKMSKeyARN: !Ref ConnectCTRStreamKMSKeyARN
         AWSRegion: !Ref AWSRegion
         VMXPresignerArn: !If
           - NonGuidedOptions


### PR DESCRIPTION
*Issue #, if available:*

Description of changes: This pull request enhances the functionality of Kinesis Data Streams when using customer-managed Customer Master Keys (CMKs) for server-side encryption. While the default AWS-managed KMS key works seamlessly, customer-managed keys require additional configuration to ensure proper operation.

Changes made in this pull request:

- Implemented KMS key policies specifically tailored for the encryption key used in Kinesis Data Streams.
- Ensured that the necessary permissions are in place for the customer-managed KMS key.
- Tested the implementation to verify that encryption and decryption operations function correctly with the configured key policies.

Please review the modifications and provide any feedback or suggestions for improvement.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.